### PR TITLE
Potential enhancement to support overrides on translated attributes in derived classes

### DIFF
--- a/Microsoft.Linq.Translations.Test/App.config
+++ b/Microsoft.Linq.Translations.Test/App.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/Microsoft.Linq.Translations.Test/Microsoft.Linq.Translations.Test.csproj
+++ b/Microsoft.Linq.Translations.Test/Microsoft.Linq.Translations.Test.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Linq.Translations.Test</RootNamespace>
+    <AssemblyName>Microsoft.Linq.Translations.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Effort">
+      <HintPath>..\packages\Effort.EF6.1.1.4\lib\net45\Effort.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="NMemory">
+      <HintPath>..\packages\NMemory.1.0.1\lib\net45\NMemory.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.0.5813.39031, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OverrideTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Linq.Translations.csproj">
+      <Project>{9b67398b-02a2-4f47-84b8-9cb3c8913ec2}</Project>
+      <Name>Microsoft.Linq.Translations</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Microsoft.Linq.Translations.Test/OverrideTests.cs
+++ b/Microsoft.Linq.Translations.Test/OverrideTests.cs
@@ -1,0 +1,189 @@
+﻿using Microsoft.Linq.Translations;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Deltafs.Platinum.InMemoryDatabase.IntegrationTests
+{
+  /// <summary>
+  ///  Microsoft.Liq.Translations is a third party linrary we use to simplify the definition of Linq-to-entities friendly
+  ///  calculated fields in entities, we have made some minor enhancements to the library these tests test those enhancements
+  /// </summary>
+  [TestFixture]
+  public class OverrideTests
+  {
+
+    public class DemoBaseClass
+    {
+      [Key]
+      public Int32 pk { get; set; }
+      public virtual String NormalAttribute { get; set; }
+      public virtual String CalculatedAttribute
+      {
+        get
+        {
+          return expCalculatedAttribute.Evaluate(this);
+        }
+      }
+
+      private static CompiledExpression<DemoBaseClass, String> expCalculatedAttribute =
+        DefaultTranslationOf<DemoBaseClass>.Property(p => p.CalculatedAttribute)
+          .Is(o => o.NormalAttribute);
+    }
+
+    public class DemoDerivedClass1 : DemoBaseClass
+    {
+      public override string NormalAttribute
+      {
+        get
+        {
+          return "Override 1";
+        }
+        set
+        {
+          base.NormalAttribute = value;
+        }
+      }
+
+      public override string CalculatedAttribute
+      {
+        get
+        {
+          return expDerivedClassOneCalculation.Evaluate(this);
+        }
+      }
+
+      private static CompiledExpression<DemoDerivedClass1, String> expDerivedClassOneCalculation =
+        DefaultTranslationOf<DemoDerivedClass1>.Property(p => p.CalculatedAttribute)
+          .Is(o => "Calculated Override 1");
+
+    }
+
+    public class DemoDerivedClass2 : DemoDerivedClass1
+    {
+      public override string NormalAttribute
+      {
+        get
+        {
+          return "Override 2";
+        }
+        set
+        {
+          base.NormalAttribute = value;
+        }
+      }
+    }
+
+    public class DemoDerivedClass3 : DemoBaseClass
+    {
+      public override string NormalAttribute
+      {
+        get
+        {
+          return "Override 3";
+        }
+        set
+        {
+          base.NormalAttribute = value;
+        }
+      }
+    }
+
+    public class DemoContext : DbContext
+    {
+      public DemoContext(DbConnection connection)
+        : base(connection, true)
+      {
+      }
+
+      public virtual DbSet<DemoBaseClass> DemoBaseClasses { get; set; }
+      public virtual DbSet<DemoDerivedClass1> DemoDerivedClassOnes { get; set; }
+      public virtual DbSet<DemoDerivedClass2> DemoDerivedClassTwos { get; set; }
+      public virtual DbSet<DemoDerivedClass3> DemoDerivedClassThrees { get; set; }
+    }
+
+    private void SeedContext(DemoContext context)
+    {
+      //seed some data in
+      var demo = new DemoBaseClass() { NormalAttribute = "TEST" };
+      context.DemoBaseClasses.Add(demo);
+
+      var demo1 = new DemoDerivedClass1() { NormalAttribute = "TEST1" };
+      context.DemoDerivedClassOnes.Add(demo1);
+
+      var demo2 = new DemoDerivedClass2() { NormalAttribute = "TEST2" };
+      context.DemoDerivedClassTwos.Add(demo2);
+
+      var demo3 = new DemoDerivedClass3() { NormalAttribute = "TEST3" };
+      context.DemoDerivedClassThrees.Add(demo3);
+
+      context.SaveChanges();
+    }
+
+    [Test]
+    public void LinqTranslations_NormalAttribute_NormalOverrideBehaviour()
+    {
+      using (var connection = Effort.DbConnectionFactory.CreateTransient())
+      {
+        using (var context = new DemoContext(connection))
+        {
+          SeedContext(context);
+        }
+
+        using (var context = new DemoContext(connection))
+        {
+          var result = context.DemoBaseClasses.First().NormalAttribute;
+          Assert.AreEqual("TEST", result);
+
+          var result1 = context.DemoDerivedClassOnes.First().NormalAttribute;
+          Assert.AreEqual("Override 1", result1);
+
+          var result2 = context.DemoDerivedClassTwos.First().NormalAttribute;
+          Assert.AreEqual("Override 2", result2);
+
+          var result3 = context.DemoDerivedClassThrees.First().NormalAttribute;
+          Assert.AreEqual("Override 3", result3);
+        }
+      }
+    }
+
+    [Test]
+    public void LinqTranslations_CalculatedAttribute_OverrideBehaviour()
+    {
+      using (var connection = Effort.DbConnectionFactory.CreateTransient())
+      {
+        using (var context = new DemoContext(connection))
+        {
+          SeedContext(context);
+        }
+
+        using (var context = new DemoContext(connection))
+        {
+          var qry = from m in context.DemoBaseClasses
+                    select m.CalculatedAttribute;
+          Assert.AreEqual("TEST", qry.WithTranslations().First());
+
+          var qry1 = from m in context.DemoDerivedClassOnes
+                     select m.CalculatedAttribute;
+          Assert.AreEqual("Calculated Override 1", qry1.WithTranslations().First());
+
+          var qry2 = from m in context.DemoDerivedClassTwos
+                     select m.CalculatedAttribute;
+          Assert.AreEqual("Calculated Override 1", qry2.WithTranslations().First());
+
+          var qry3 = from m in context.DemoDerivedClassThrees
+                     select m.CalculatedAttribute;
+          Assert.AreEqual("Override 3", qry3.WithTranslations().First());
+
+        }
+      }
+    }
+  }
+
+}

--- a/Microsoft.Linq.Translations.Test/Properties/AssemblyInfo.cs
+++ b/Microsoft.Linq.Translations.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Linq.Translations.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Microsoft.Linq.Translations.Test")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d484ee7c-429c-4e9c-b14b-c6febe2bf7f7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Microsoft.Linq.Translations.Test/packages.config
+++ b/Microsoft.Linq.Translations.Test/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Effort.EF6" version="1.1.4" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
+  <package id="NMemory" version="1.0.1" targetFramework="net45" />
+  <package id="NUnit" version="3.0.1" targetFramework="net45" />
+</packages>

--- a/Microsoft.Linq.Translations.csproj
+++ b/Microsoft.Linq.Translations.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <NoStandardLibraries>false</NoStandardLibraries>
+    <AssemblyName>ClassLibrary</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>Microsoft.Linq.Translations</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Microsoft.Linq.Translations\Argument.cs" />
+    <Compile Include="Microsoft.Linq.Translations\CompiledExpression.cs" />
+    <Compile Include="Microsoft.Linq.Translations\DefaultTranslationOf.cs" />
+    <Compile Include="Microsoft.Linq.Translations\ExpressiveExtensions.cs" />
+    <Compile Include="Microsoft.Linq.Translations\Properties\AssemblyInfo.cs" />
+    <Compile Include="Microsoft.Linq.Translations\TranslationMap.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
+  <ProjectExtensions>
+    <VisualStudio AllowExistingFolder="true" />
+  </ProjectExtensions>
+</Project>

--- a/Microsoft.Linq.Translations.sln
+++ b/Microsoft.Linq.Translations.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Linq.Translations", "Microsoft.Linq.Translations\Microsoft.Linq.Translations.xproj", "{BC3BD9FC-AEBF-4C19-8110-00FAB71BEBAF}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Linq.Translations", "Microsoft.Linq.Translations.csproj", "{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BC3BD9FC-AEBF-4C19-8110-00FAB71BEBAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BC3BD9FC-AEBF-4C19-8110-00FAB71BEBAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BC3BD9FC-AEBF-4C19-8110-00FAB71BEBAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BC3BD9FC-AEBF-4C19-8110-00FAB71BEBAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Linq.Translations.sln
+++ b/Microsoft.Linq.Translations.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Linq.Translations", "Microsoft.Linq.Translations.csproj", "{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Linq.Translations.Test", "Microsoft.Linq.Translations.Test\Microsoft.Linq.Translations.Test.csproj", "{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B67398B-02A2-4F47-84B8-9CB3C8913EC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55BE9C1A-EF98-44F7-9ECC-A13C8AE80125}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Linq.Translations/Argument.cs
+++ b/Microsoft.Linq.Translations/Argument.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Linq.Translations
 
         public static void EnsureIsAssignableFrom<T>(string parameterName, Type type)
         {
-            if (!typeof(T).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            if (!typeof(T).IsAssignableFrom(type))
                 throw new ArgumentException(string.Format("Type {0} must be assignable from {1}", type.Name, typeof(T).Name), parameterName);
         }
 

--- a/Microsoft.Linq.Translations/ExpressiveExtensions.cs
+++ b/Microsoft.Linq.Translations/ExpressiveExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Linq.Translations
                     return VisitCompiledExpression(cp, node.Expression);
                 }
 
-                if (typeof(CompiledExpression).GetTypeInfo().IsAssignableFrom(node.Member.DeclaringType.GetTypeInfo()))
+                if (typeof(CompiledExpression).IsAssignableFrom(node.Member.DeclaringType))
                 {
                     return VisitCompiledExpression(cp, node.Expression);
                 }

--- a/Microsoft.Linq.Translations/TranslationMap.cs
+++ b/Microsoft.Linq.Translations/TranslationMap.cs
@@ -26,8 +26,16 @@ namespace Microsoft.Linq.Translations
         {
             Argument.EnsureNotNull("property", property);
             Argument.EnsureNotNull("compiledExpression", compiledExpression);
-
-            Add(((MemberExpression)property.Body).Member, compiledExpression);
+            
+            // deltafsdevelopment May 2013 - Fix to the code here so that if the prop is an override the derived class type name is
+            // is stored in the translation map not the base class name that way we can have different expressions mapped to the
+            // same override in different derived classes
+            if (property.Parameters.Count > 0)
+            {
+              ParameterExpression expr = property.Parameters[0];
+              PropertyInfo pi = expr.Type.GetProperty(((MemberExpression)property.Body).Member.Name);
+              base.Add(pi, compiledExpression);
+            }
         }
 
         public CompiledExpression<T, TResult> Add<T, TResult>(Expression<Func<T, TResult>> property, Expression<Func<T, TResult>> expression)


### PR DESCRIPTION
First off - many thanks @damieng for creating this excellent extension to Linq-to-entities I have been using it for the passed 5 years with great success. 

The only niggle has been around mapping calculated attributes in derived classes where I want to override the attribute mapped in the base class with a new calculation in the derived class. This didn't work out of the box.

This set of changes represent my fix/enhancement for that functionality.

I have included an nUnit test project to demonstrate the changes which utilises the excellent Effort in memory database stub.

Unfortunately I am still on VS 2013 so in order to demo these changes I had to unwind the upgrade to VS 2015 and project.json ... 